### PR TITLE
Auth headers (#125)

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+0.8.0b9:
+  Fix push headers.
+  Added cache to headers [thank KoolLSL for pointing that out]
+  Force SSE client over requests not cloudscraper.
 0.8.0b8:
   Ping wired doorbell.
   Try proper device id for cloud flare

--- a/pyaarlo/__init__.py
+++ b/pyaarlo/__init__.py
@@ -45,7 +45,7 @@ from .util import time_to_arlotime
 
 _LOGGER = logging.getLogger("pyaarlo")
 
-__version__ = "0.8.0b8"
+__version__ = "0.8.0b9"
 
 
 class PyArlo(object):

--- a/pyaarlo/backend.py
+++ b/pyaarlo/backend.py
@@ -552,7 +552,7 @@ class ArloBackEnd(object):
                 self._event_client = SSEClient(
                     self._arlo,
                     self._arlo.cfg.host + SUBSCRIBE_PATH,
-                    session=self._session,
+                    headers=self._headers(),
                     reconnect_cb=self._sse_reconnected,
                 )
             else:
@@ -564,7 +564,7 @@ class ArloBackEnd(object):
                 self._event_client = SSEClient(
                     self._arlo,
                     self._arlo.cfg.host + SUBSCRIBE_PATH,
-                    session=self._session,
+                    headers=self._headers(),
                     reconnect_cb=self._sse_reconnected,
                     timeout=self._arlo.cfg.stream_timeout,
                 )
@@ -673,19 +673,52 @@ class ArloBackEnd(object):
         self._sub_id = "subscriptions/" + self._web_id
         self._expires_in = body["expiresIn"]
 
-    def _auth(self):
-        headers = {
+    def _auth_headers(self):
+        return {
             "Accept": "application/json, text/plain, */*",
             "Accept-Encoding": "gzip, deflate, br",
             "Accept-Language": "en-GB,en;q=0.9,en-US;q=0.8",
+            "Cache-Control": "no-cache",
             "Origin": ORIGIN_HOST,
+            "Pragma": "no-cache",
             "Referer": REFERER_HOST,
+            # "Sec-Ch-Ua": '"Not.A/Brand";v="8", "Chromium";v="114", "Google Chrome";v="114"',
+            # "Sec-Ch-Ua-Mobile": "?0",
+            # "Sec-Ch-Ua-Platform": "Linux",
+            # "Sec-Fetch-Dest": "empty",
+            # "Sec-Fetch-Mode": "cors",
+            # "Sec-Fetch-Site": "same-site",
             "Source": "arloCamWeb",
             "User-Agent": self._user_agent,
-            "x-user-device-id": self._user_device_id,
-            "x-user-device-automation-name": "QlJPV1NFUg==",
-            "x-user-device-type": "BROWSER",
+            "X-User-Device-Automation-name": "QlJPV1NFUg==",
+            "X-User-Device-Id": self._user_device_id,
+            "X-User-Device-Type": "BROWSER",
         }
+
+    def _headers(self):
+        return {
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Accept-Language": "en-GB,en;q=0.9,en-US;q=0.8",
+            "Auth-Version": "2",
+            "Authorization": self._token,
+            "Cache-Control": "no-cache",
+            "Content-Type": "application/json; charset=utf-8;",
+            "Origin": ORIGIN_HOST,
+            "Pragma": "no-cache",
+            "Referer": REFERER_HOST,
+            # "SchemaVersion": "1",
+            # "Sec-Ch-Ua": '"Not.A/Brand";v="8", "Chromium";v="114", "Google Chrome";v="114"',
+            # "Sec-Ch-Ua-Mobile": "?0",
+            # "Sec-Ch-Ua-Platform": "Linux",
+            # "Sec-Fetch-Dest": "empty",
+            # "Sec-Fetch-Mode": "cors",
+            # "Sec-Fetch-Site": "same-site",
+            "User-Agent": self._user_agent,
+        }
+
+    def _auth(self):
+        headers = self._auth_headers()
 
         # Handle 1015 error
         attempt = 0
@@ -798,7 +831,12 @@ class ArloBackEnd(object):
                 self.debug(
                     "starting auth with {}".format(self._arlo.cfg.tfa_type)
                 )
-                body = self.auth_post(AUTH_START_PATH, {"factorId": factor_id}, headers)
+                payload = {
+                    "factorId": factor_id,
+                    "factorType": "",
+                    "userId": self._user_id
+                }
+                body = self.auth_post(AUTH_START_PATH, payload, headers)
                 if body is None:
                     self._arlo.error("2fa startAuth failed")
                     return False
@@ -829,19 +867,8 @@ class ArloBackEnd(object):
         return True
 
     def _validate(self):
-        headers = {
-            "Accept": "application/json, text/plain, */*",
-            "Accept-Encoding": "gzip, deflate, br",
-            "Accept-Language": "en-GB,en;q=0.9,en-US;q=0.8",
-            "Authorization": self._token64,
-            "Origin": ORIGIN_HOST,
-            "Referer": REFERER_HOST,
-            "User-Agent": self._user_agent,
-            "Source": "arloCamWeb",
-            "x-user-device-id": self._user_device_id,
-            "x-user-device-automation-name": "QlJPV1NFUg==",
-            "x-user-device-type": "BROWSER",
-        }
+        headers = self._auth_headers()
+        headers["Authorization"] = self._token64
 
         # Validate it!
         validated = self.auth_get(
@@ -884,19 +911,7 @@ class ArloBackEnd(object):
         self._save_session()
 
         # update sessions headers
-        headers = {
-            "Accept": "application/json",
-            "Accept-Encoding": "gzip, deflate, br",
-            "Accept-Language": "en-GB,en;q=0.9,en-US;q=0.8",
-            "Auth-Version": "2",
-            "Authorization": self._token,
-            "Content-Type": "application/json; charset=utf-8;",
-            "Origin": ORIGIN_HOST,
-            "Pragma": "no-cache",
-            "Referer": REFERER_HOST,
-            "SchemaVersion": "1",
-            "User-Agent": self._user_agent,
-        }
+        headers = self._headers()
         self._session.headers.update(headers)
 
         # Grab a session. Needed for new session and used to check existing

--- a/pyaarlo/constant.py
+++ b/pyaarlo/constant.py
@@ -302,7 +302,7 @@ USER_AGENTS = {
         "Gecko/20100101 Firefox/85.0",
     "linux":
         "Mozilla/5.0 (X11; Linux x86_64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36"
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
 }
 
 CERT_BEGIN = '-----BEGIN CERTIFICATE-----\n'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ requests
 click
 pycryptodome
 unidecode
-cloudscraper>=1.2.58
+cloudscraper>=1.2.71
 paho-mqtt
 cryptography

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readme():
 setup(
 
     name='pyaarlo',
-    version='0.8.0b8',
+    version='0.8.0b9',
     packages=['pyaarlo'],
 
     python_requires='>=3.6',


### PR DESCRIPTION
* Tidy auth headers.

* Track Arlo backend changes.

1. Add in caching headers.
2. Make SSEclient use requests directly.

* Track Arlo backend changes.

3. Bump the requirements.